### PR TITLE
build: Add patched version of versionize_derive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,10 @@ vfio-bindings = { git = "https://github.com/rust-vmm/vfio", branch = "main", fea
 vm-memory = { version = "0.10.0", features = ["backend-mmap", "backend-atomic"] }
 vmm-sys-util = "0.11.0"
 
+# List of patched crates
+[patch.crates-io]
+versionize_derive = { git = "https://github.com/cloud-hypervisor/versionize_derive", branch = "ch" }
+
 [dev-dependencies]
 argh = "0.1.9"
 env_logger = "0.10.0"


### PR DESCRIPTION
This is necessary to build the gpio sample application that currently
uses the pci crate from cloud-hypervisor.

Signed-off-by: Rob Bradford <rbradford@rivosinc.com>
