### PR TITLE
Update for latest QEMU version

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,7 +136,6 @@ struct DeviceGetInfo {
     flags: u32,
     num_regions: u32,
     num_irqs: u32,
-    cap_offset: u32,
 }
 
 #[repr(C)]
@@ -1024,7 +1023,6 @@ impl Server {
                         },
                     num_regions: self.regions.len() as u32,
                     num_irqs: self.irqs.len() as u32,
-                    cap_offset: 0,
                 };
                 stream
                     .write_all(reply.as_slice())


### PR DESCRIPTION
- Revert "server: Add missing field to DeviceGetInfo"
- prototocol: Correctly structure capabilities
