### PR TITLE
build: Bump vm-memory from 0.10.0 to 0.11.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ serde_derive = "1.0.149"
 serde_json = "1.0.93"
 thiserror = "1.0.38"
 vfio-bindings = { git = "https://github.com/rust-vmm/vfio", branch = "main", features = ["fam-wrappers"] }
-vm-memory = { version = "0.10.0", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = "0.11.0", features = ["backend-mmap", "backend-atomic"] }
 vmm-sys-util = "0.11.0"
 
 [dev-dependencies]


### PR DESCRIPTION
### Summary of the PR

This PR bumps `vm-memory` from 0.10.0 to 0.11.0 so that the consumers of the `vfio-user` crates (e.g. Cloud Hypervisor) can also bump to use latest `vm-memory` crate.


### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
