### PR TITLE
protocol: Remove hardcoded page size

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 
 use bitflags::bitflags;
 use libc::{c_void, iovec, EINVAL};
+use libc::{sysconf, _SC_PAGESIZE};
 use std::ffi::CString;
 use std::fs::File;
 use std::io::{IoSlice, Read, Write};
@@ -90,8 +91,14 @@ const fn default_max_data_xfer_size() -> u32 {
     1048576
 }
 
-const fn default_migration_capabilities() -> MigrationCapabilities {
-    MigrationCapabilities { pgsize: 4096 }
+#[inline(always)]
+fn pagesize() -> u32 {
+    // SAFETY: sysconf
+    unsafe { sysconf(_SC_PAGESIZE) as u32 }
+}
+
+fn default_migration_capabilities() -> MigrationCapabilities {
+    MigrationCapabilities { pgsize: pagesize() }
 }
 
 bitflags! {


### PR DESCRIPTION
### Summary of the PR

The hardcode of 4096 only works well on kernel with CONFIG_ARM64_4K_PAGES=y,when the kernel's config is CONFIG_ARM64_64K_PAGES=y,vfio-user works fail.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
