### PR TITLE
build: Bump vm-memory and vmm-sys-util

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ serde_derive = "1.0.149"
 serde_json = "1.0.93"
 thiserror = "1.0.38"
 vfio-bindings = { git = "https://github.com/rust-vmm/vfio", branch = "main", features = ["fam-wrappers"] }
-vm-memory = { version = "0.13.1", features = ["backend-mmap", "backend-atomic"] }
-vmm-sys-util = "0.11.0"
+vm-memory = { version = "0.14.0", features = ["backend-mmap", "backend-atomic"] }
+vmm-sys-util = "0.12.1"
 
 [dev-dependencies]
 argh = "0.1.9"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -355,11 +355,8 @@ impl Client {
 
         debug!("Reply: {:?}", server_version);
 
-        let mut server_version_data = Vec::new();
-        server_version_data.resize(
-            server_version.header.message_size as usize - size_of::<Version>(),
-            0,
-        );
+        let mut server_version_data =
+            vec![0; server_version.header.message_size as usize - size_of::<Version>()];
         self.stream
             .read_exact(server_version_data.as_mut_slice())
             .map_err(Error::StreamRead)?;
@@ -897,8 +894,8 @@ impl Server {
                     .read_exact(&mut client_version.as_mut_slice()[size_of::<Header>()..])
                     .map_err(Error::StreamRead)?;
 
-                let mut raw_version_data = Vec::new();
-                raw_version_data.resize(header.message_size as usize - size_of::<Version>(), 0u8);
+                let mut raw_version_data =
+                    vec![0; header.message_size as usize - size_of::<Version>()];
                 stream
                     .read_exact(&mut raw_version_data)
                     .map_err(Error::StreamRead)?;


### PR DESCRIPTION
### Summary of the PR

Bump to vm-memory v0.14.0 and vmm-sys-util v0.12.1.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
