### PR TITLE
vfio_user: fix off-by-one in array bounds checking

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1047,7 +1047,7 @@ impl Server {
                     .read_exact(&mut cmd.as_mut_slice()[size_of::<Header>()..])
                     .map_err(Error::StreamRead)?;
 
-                if cmd.region_info.index as usize > self.regions.len() {
+                if cmd.region_info.index as usize >= self.regions.len() {
                     return Err(Error::InvalidInput);
                 }
 
@@ -1075,7 +1075,7 @@ impl Server {
                     .read_exact(&mut cmd.as_mut_slice()[size_of::<Header>()..])
                     .map_err(Error::StreamRead)?;
 
-                if cmd.index as usize > self.irqs.len() {
+                if cmd.index as usize >= self.irqs.len() {
                     return Err(Error::InvalidInput);
                 }
 
@@ -1107,7 +1107,7 @@ impl Server {
                     .read_exact(&mut cmd.as_mut_slice()[size_of::<Header>()..])
                     .map_err(Error::StreamRead)?;
 
-                if cmd.index as usize > self.irqs.len() {
+                if cmd.index as usize >= self.irqs.len() {
                     return Err(Error::InvalidInput);
                 }
 
@@ -1141,7 +1141,7 @@ impl Server {
 
                 let (region, offset, count) = (cmd.region, cmd.offset, cmd.count);
 
-                if region as usize > self.regions.len() {
+                if region as usize >= self.regions.len() {
                     return Err(Error::InvalidInput);
                 }
 
@@ -1178,7 +1178,7 @@ impl Server {
 
                 let (region, offset, count) = (cmd.region, cmd.offset, cmd.count);
 
-                if region as usize > self.regions.len() {
+                if region as usize >= self.regions.len() {
                     return Err(Error::InvalidInput);
                 }
 


### PR DESCRIPTION
### Summary of the PR

The existing checks didn't catch the case where the other side asked for region/irq n when there are n entries in the vector. This results in ugly crashes like this:

```
thread 'main' panicked at .../vfio-user/src/lib.rs:1082:37: index out of bounds: the len is 0 but the index is 0 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
