### PR TITLE
Fix Command::DmaMap

### DIFF
--- a/examples/gpio/main.rs
+++ b/examples/gpio/main.rs
@@ -148,7 +148,7 @@ impl ServerBackend for TestBackend {
         offset: u64,
         address: u64,
         size: u64,
-        fd: Option<&File>,
+        fd: Option<File>,
     ) -> Result<(), std::io::Error> {
         info!("dma_map flags = {flags:?} offset = {offset} address = {address} size = {size} fd = {fd:?}");
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -957,7 +957,7 @@ impl Server {
                         cmd.offset,
                         cmd.address,
                         cmd.size,
-                        if fds.len() > 1 { Some(&fds[0]) } else { None },
+                        if !fds.is_empty() { Some(&fds[0]) } else { None },
                     )
                     .map_err(Error::Backend)?;
 


### PR DESCRIPTION
### Summary of the PR

This PR fixes handling the DmaMap command. There are two issues:

1. When a `DmaMap` message arrives with one file descriptor, the backend still receives `None` in its `dma_map` call, because for `fds.len() == 1` the code passes `None` instead of `fds[0]`.
2. If the callee wants to hang on to the `File` object it gets via `backend.dma_map()`, they have a hard time, because we currently only pass a `&File`. Change this to `File` to give the callee more options to hang on to the `File` without resorting to unsafe `libc::dup()`. 

Technically only 1 is strictly necessary to get DMA mapping working:

```
2025-04-23T15:50:37.487297Z  INFO usbvfiod: dma_map flags = READ_ONLY | WRITE_ONLY | READ_WRITE offset = 0 address = 4294967296 size = 1073741824 fd = Some(File { fd: 6, path: "/memfd:ch_ram (deleted)", read: true, write: true })
```

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
